### PR TITLE
Fixed httpExporter for multipage diagrams

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
           "default": "http://www.plantuml.com/plantuml",
           "description": "Plantuml server to generate UML diagrams on-the-fly."
         },
+        "plantuml.urlServerIndexParameter": {
+          "type": "string",
+          "default": "",
+          "description": "Optional index parameter name for multipage diagrams. (e.g. uri?idx=${n})"
+        },
         "plantuml.urlFormat": {
           "type": "string",
           "default": "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,10 @@ class ConfigReader {
         return this._read<string>('urlServer') || "http://www.plantuml.com/plantuml";
     }
 
+    get urlServerIndexParameter(): string {
+        return this._read<string>('urlServerIndexParameter');
+    }
+
     get urlFormat(): string {
         return this._read<string>('urlFormat');
     }


### PR DESCRIPTION
Hey qjebbs,

your commit https://github.com/qjebbs/vscode-plantuml/commit/1043bb159be13e9ec570b5b8b863d1fd21e43de2 unfortunately broke the httpExporter Logic as well. I updated the code accordingly.

You can test it against http://plantuml.rado0x54.com:

```
    "plantuml.urlServer": "http://plantuml.rado0x54.com",
    "plantuml.previewFromUrlServer": true,
    "plantuml.urlServerIndexParameter": "idx"
```


e.g.
http://plantuml.rado0x54.com/png/IzIrIx9Io4ZDoSctvifBBIz8J4zLWD8bcIKvgLn9kdQ92bOAIOd9sGhvUI0v1P2aDG00?idx=0
&
http://plantuml.rado0x54.com/png/IzIrIx9Io4ZDoSctvifBBIz8J4zLWD8bcIKvgLn9kdQ92bOAIOd9sGhvUI0v1P2aDG00?idx=1

Quick release would be appreciated.

