### PR TITLE
add plantuml syntax highlighting in markdown fenced block (in editor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,16 @@
         "language": "diagram",
         "scopeName": "source.wsd",
         "path": "./syntaxes/diagram.tmLanguage"
+      },
+      {
+        "scopeName": "markdown.plantuml.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.plantuml": "javascript"
+        }
       }
     ],
     "commands": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,28 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:markup.fenced_code.block.markdown",
+    "patterns": [
+        {
+            "include": "#plantuml-code-block"
+        }
+    ],
+    "repository": {
+        "plantuml-code-block": {
+            "begin": "plantuml(\\s+[^`~]*)?$",
+            "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.plantuml",
+                    "patterns": [
+                        {
+                            "include": "source.wsd"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.plantuml.codeblock"
+}


### PR DESCRIPTION
This is to add support of the syntax highlighting in the editor in markdown files.

This is inspired from https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example

Tested successfully, example:

![image](https://user-images.githubusercontent.com/13764060/36352162-1f2222de-14b5-11e8-9088-87284fa12a19.png)
