### PR TITLE
Feat: format opt sequence group blocks

### DIFF
--- a/src/plantuml/formatRules.ts
+++ b/src/plantuml/formatRules.ts
@@ -185,7 +185,7 @@ let rules = <RulesWriting>{
                 {
                     comment: "sequence grouping",
                     isBlock: true,
-                    begin: /{{LB}}(loop|par|break|critical|group)\b\s*(.+)?{{LE}}/i,
+                    begin: /{{LB}}(opt|loop|par|break|critical|group)\b\s*(.+)?{{LE}}/i,
                     end: /{{LB}}(end){{LE}}/i,
                     beginCaptures: {
                         1: ElementType.word,


### PR DESCRIPTION
hey @qjebbs been using your extension quite a lot in the past weeks. it's **great**. i was wondering though why block formatting for **opt** sequence groups is missing? 

**opt** keyword is mentioned on plantuml sequence diagram documentation http://plantuml.com/sequence-diagram

![image](https://user-images.githubusercontent.com/2894615/36932986-ee56e442-1ed1-11e8-8402-6c6aaf859229.png)

So i added **opt** keyword to the block formatting rules for the other sequence groups. 😃 