### PR TITLE
Use https instead of http for default online render server url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
         },
         "plantuml.server": {
           "type": "string",
-          "default": "http://www.plantuml.com/plantuml",
+          "default": "https://www.plantuml.com/plantuml",
           "description": "%plantuml.configuration.server%"
         },
         "plantuml.serverIndexParameter": {

--- a/src/plantuml/config.ts
+++ b/src/plantuml/config.ts
@@ -115,7 +115,7 @@ class Config extends ConfigReader {
     }
 
     get server(): string {
-        return this.read<string>('server') || "http://www.plantuml.com/plantuml";
+        return this.read<string>('server') || "https://www.plantuml.com/plantuml";
     }
 
     get serverIndexParameter(): string {


### PR DESCRIPTION
Related to issue #175

Plantuml in markdown preview only works, when Preview Security Settings are set to "Allow insecure content". When setting plantuml.render to HTTPS instead of HTTP, plantuml preview also works with Strict Security Settings.

This pull request updates the default render settings to HTTPS instead of HTTP.


