### PR TITLE
update blue style - add coherence to activity diagram

### DIFF
--- a/includes/styles/blue.wsd
+++ b/includes/styles/blue.wsd
@@ -54,6 +54,10 @@ skinparam {
                 Size 12
             }
         }
+        Diamond {
+            BackgroundColor AliceBlue
+            BorderColor SteelBlue
+        }
     }
     State {
         StartColor Black


### PR DESCRIPTION
The diamond used for branches in activity diagram now uses the same style as the other elements.