### PR TITLE
VS Code Server: define execution location

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,7 @@
       ]
     }
   },
+  "extensionKind": ["ui", "workspace"],
   "scripts": {
     "vscode:prepublish": "npm run buildsyntax && tsc -p ./",
     "compile": "tsc -p ./",


### PR DESCRIPTION
This setting tells VS Code where to install the extension in a remote workspace setup.

I use Docker and run my project in a Linux container. I also use the server-render setting and it works fine. The extension is installed locally by default, not inside the remote container. You could probably install JAVA inside the remote container and install the extension remotely, but I like using the PlantUML docker container.

Note that I had to add the extension's settings for the workspace, the user-settings do not apply. I am not sure if this is a bug in how the settings are handled at the moment by VS Code. (The remote container has its own settings file too.)

https://code.visualstudio.com/api/advanced-topics/remote-extensions#common-problems