### PR TITLE
Initial support for "return" keyword

### DIFF
--- a/snippets/sequence.json
+++ b/snippets/sequence.json
@@ -192,5 +192,10 @@
 		"prefix": "sequence➤deactivate・lifeline",
 		"body": "deactivate ${1:objAlias}\n$0",
 		"description": "Shows the timed deactive execution context for all subsequent message calls to the nominated object"
+	},
+	"Sequence Diagram Lifeline Return": {
+		"prefix": "sequence➤return・lifeline",
+		"body": "return ${1:label}\n$0",
+		"description": "Indicates to return to the latest lifeline activation"
 	}
 }

--- a/syntaxes/diagram.yaml-tmLanguage
+++ b/syntaxes/diagram.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction)\s*$


### PR DESCRIPTION
Hi.

Recent PlantUML sequence diagrams have an additional "return" keyword.

e.g.
```
@startuml
Bob -> Alice : hello
activate Alice
Alice -> Alice : some action
return bye
@enduml
```

I added initial support for the "return" keyword.