### PR TITLE
Ensure comment toggles work in markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "2.13.3",
+  "version": "2.13.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
           "text.html.markdown"
         ],
         "embeddedLanguages": {
-          "meta.embedded.block.plantuml": "javascript"
+          "meta.embedded.block.plantuml": "diagram"
         }
       }
     ],
@@ -344,7 +344,10 @@
       ]
     }
   },
-  "extensionKind": ["workspace", "ui"],
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
   "scripts": {
     "vscode:prepublish": "npm run buildsyntax && tsc -p ./",
     "compile": "tsc -p ./",


### PR DESCRIPTION
Fixes #305 

Toggle comments now work in markdown code fences.

NOTE: Running `npm install` automatically bumped the package version. I'm guessing for some reason this might have been forgotten in the last commit or this is a side effect of the publish release process.