### PR TITLE
Check before using the `parentUri.fsPath` property

### DIFF
--- a/src/plantuml/diagram/include.ts
+++ b/src/plantuml/diagram/include.ts
@@ -22,7 +22,11 @@ let _route: string[] = []
 
 export function getContentWithInclude(diagram: Diagram): string {
     _included = {};
-    _route = [diagram.parentUri.fsPath];
+    if (diagram.parentUri) {
+        _route = [diagram.parentUri.fsPath];
+    } else {
+        _route = [];
+    }
     // console.log('Start from:', _route[0]);
     let searchPaths = getSearchPaths(diagram.parentUri);
     return resolveInclude(diagram.lines, searchPaths);


### PR DESCRIPTION
When the `diagram` was created with the content-only constructor, the document information is missing, and therefore `diagram.parentUri` property is `undefined`. A check is necessary before accessing the `.fsPath` property.