### PR TITLE
Fix the include preprocessor creating nested diagrams

### DIFF
--- a/src/plantuml/diagram/include.ts
+++ b/src/plantuml/diagram/include.ts
@@ -10,7 +10,7 @@ const STARTSUB_TEST_REG = /^\s*!startsub\s+(\w+)/i;
 const ENDSUB_TEST_REG = /^\s*!endsub\b/i;
 
 const START_DIAGRAM_REG = /(^|\r?\n)\s*@start.*\r?\n/i;
-const END_DIAGRAM_REG = /\r?\n\s*@end.*(\r?\n|$)/i;
+const END_DIAGRAM_REG = /\r?\n\s*@end.*(\r?\n|$)(?!.*\r?\n\s*@end.*(\r?\n|$))/i;
 
 interface FileSubBlocks {
     [key: string]: string[];

--- a/src/plantuml/diagram/include.ts
+++ b/src/plantuml/diagram/include.ts
@@ -9,6 +9,9 @@ const INCLUDE_REG = /^\s*!(include(?:sub)?)\s+(.+?)(?:!(\w+))?$/i;
 const STARTSUB_TEST_REG = /^\s*!startsub\s+(\w+)/i;
 const ENDSUB_TEST_REG = /^\s*!endsub\b/i;
 
+const START_DIAGRAM_REG = /(^|\n)\s*@start.*\n/i;
+const END_DIAGRAM_REG = /\n\s*@end.*(\n|$)/i;
+
 interface FileSubBlocks {
     [key: string]: string[];
 }
@@ -87,6 +90,10 @@ function getIncludeContent(file: string): string {
     let result = resolveInclude(content, getSearchPaths(vscode.Uri.file(file)));
     _route.pop();
     // console.log('Leaving:', file);
+
+    result = result.replace(START_DIAGRAM_REG, "$1");
+    result = result.replace(END_DIAGRAM_REG, "$1");
+
     return result;
 }
 

--- a/src/plantuml/diagram/include.ts
+++ b/src/plantuml/diagram/include.ts
@@ -9,8 +9,8 @@ const INCLUDE_REG = /^\s*!(include(?:sub)?)\s+(.+?)(?:!(\w+))?$/i;
 const STARTSUB_TEST_REG = /^\s*!startsub\s+(\w+)/i;
 const ENDSUB_TEST_REG = /^\s*!endsub\b/i;
 
-const START_DIAGRAM_REG = /(^|\n)\s*@start.*\n/i;
-const END_DIAGRAM_REG = /\n\s*@end.*(\n|$)/i;
+const START_DIAGRAM_REG = /(^|\r?\n)\s*@start.*\r?\n/i;
+const END_DIAGRAM_REG = /\r?\n\s*@end.*(\r?\n|$)/i;
 
 interface FileSubBlocks {
     [key: string]: string[];


### PR DESCRIPTION
Remove the `@start...` and `@end...` tags from an included file before adding it to the parent.

The code removes the first line, which starts (ignoring whitespaces) with `@start`.
Then it removes the last line, which starts (ignoring whitespaces) with `@end`.

Both operations remove exactly one new-line (either single `\n` or `\r\n`), so that there is no empty line but the line before and the line after don't get merged.

Fixes #298