### PR TITLE
Add commandArgs and jarArgs to the sourceExtracter

### DIFF
--- a/src/plantuml/sourceExtracter/extractSource.ts
+++ b/src/plantuml/sourceExtracter/extractSource.ts
@@ -39,14 +39,16 @@ function extract(imgs: vscode.Uri[]) {
             }
 
             let params = [
+                ...config.commandArgs(null),
                 '-Djava.awt.headless=true',
                 '-jar',
                 config.jar(null),
+                ...config.jarArgs(null),
                 "-metadata",
                 img.fsPath,
             ];
 
-            // processes.push(process);
+            // processes.push(process); 
             return pChain.then(
                 () => {
                     if (bar) {


### PR DESCRIPTION
without them, encoding settings would not be taken into account

{
    "plantuml.commandArgs": [
        "-Dfile.encoding=UTF-8"
    ],
    "plantuml.jarArgs": [
        "-charset UTF-8"
    ]
}

Fixes: #383