### PR TITLE
Fix #411 - Error in console while typing include

### DIFF
--- a/src/plantuml/diagram/include.ts
+++ b/src/plantuml/diagram/include.ts
@@ -79,7 +79,7 @@ function findFile(file: string, searchPaths: string[]): string {
 }
 
 function getIncludeContent(file: string): string {
-    if (!file) return undefined
+    if (!file || !fs.existsSync(file) || !new fs.Dirent(file).isFile()) return undefined
     // console.log('Entering:', file);
     if (_included[file]) {
         // console.log("Ignore file already included:", file);


### PR DESCRIPTION
Adds a check to see if path being included exists and is a file before tyring to read

Fixes #411 