### PR TITLE
syntax highlighting: manage full online block comment

### DIFF
--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -58,8 +58,8 @@ repository:
       end: (?i)\n
     - comment: comment block
       name: comment.block.source.wsd
-      begin: (?i)^\s*(/')
-      end: (?i)('/)\s*$
+      begin: (?i)\s*(/')
+      end: (?i)('/)\s*
   Style:
     patterns:
     - comment: inline style


### PR DESCRIPTION
Modification of `plantuml.yaml-tmLanguage` in order to manage full online block comment on syntax highlighting (See #418).

Example to be corrected:

1. Example on component/deployment diagram
```puml
@startuml
' Simple online comment
/' this is a block comment
/' until this '/

[c1]
[c2] /' block comment '/
/' block comment '/ [c3]
node n #palegreen /' block comment '/ 
@enduml
```

2. Example on sequence diagram
```puml
@startuml
/' comment '/ a->b
a->b /' comment always KO '/
autonumber 11 /' 11 '/
a<-b /' comment always KO '/
/' 13 '/ autonumber 13 
/' comment '/ a->b
@enduml
```

**Restriction**
:warning: This PR fixes the first example; but not all for the second where some syntax highlighting errors remain (see` /' comment always KO '/`)

:sos: Requesting assistance to complete the PR: any help is welcome...

Regards.