### PR TITLE
mod: syntax highlighting: Improve syntax highlighting (deployment + keywords)

### DIFF
--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,10 +90,10 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
-      match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction)\s*$
+      match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge)\s*$
     - comment: other keywords
       name: keyword.other.other.source.wsd
       match: (?i)\b(as|{(static|abstract)\})\b

--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract|class|abstract\s+class|state|autonumber(\s+stop|resume)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction)\s*$


### PR DESCRIPTION
1/ Syntax highlighting: adding **missing deployment keywords**, in order to improve syntax highlighting:
```puml
@startuml
agent agent
artifact artifact
card card
circle circle
collections collections
file file
hexagon hexagon
label label
person person
queue queue
stack stack
storage storage
@enduml
```
2/ Adding keywords:
- mainframe (on type 'line begin keywords')
- map ('line begin keywords')
- kill ('whole line keywords")
- end merge ('whole line keywords")
- repeat (adding on 'line begin keywords')
- backward ('line begin keywords')