### PR TITLE
fix: syntax highlighting: change the scope of the preprocessing keywords (VSCode vs GitHub)

### DIFF
--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -199,7 +199,7 @@ repository:
         '2': {name: keyword.other.header_legend_footer.source.wsd}
         '3': {name: meta.comment.header_legend_footer.source.wsd}
     - comment: Preprocessings
-      name: support.class.preprocessings.source.wsd
+      name: entity.name.function.preprocessings.source.wsd
       match: (?i)(!includesub|!include|!enddefinelong|!definelong|!define|!startsub|!endsub|!ifdef|!else|!endif|!ifndef)
     - comment: links
       begin: (?i)((?:(?:(?:\s+[ox]|[+*])?(?:<<|<\|?|\\\\|\\|//|\}|\^|#|0|0\))?)(?=[-.~=]))[-.~=]+(\[(?:\#(?:[0-9a-f]{6}|[0-9a-f]{3}|\w+)(?:[-\\/](?:[0-9a-f]{6}|[0-9a-f]{3}|\w+))?\b)\])?(?:(left|right|up|down)(?:[-.~=]))?[-.]*(?:(?:>>|\|?>|\\\\|\\|//|\{|\^|#|0|\(0)?(?:[ox]\s+|[+*])?))


### PR DESCRIPTION
Improve syntax highlighting for preprocessing keyword (VSCode vs GitHub), with change the scope of the preprocessing keywords:
- from `support.class.preprocessings.source.wsd`
- to `entity.name.function.preprocessings.source.wsd`

Related issues:
- Fixes qjebbs/vscode-plantuml#428
- Fixes github/linguist#5530

Ref. and intersection of:
- https://github.com/microsoft/vscode/tree/main/extensions/theme-defaults/themes
- https://github.com/primer/github-syntax-light
- https://github.com/primer/github-syntax-dark