### PR TITLE
docs: fix AdoptOpenJDK deprecation: use temurin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It's necessary to have following installed:
 #### Quick Install for Mac
 
 ```sh
-brew install --cask adoptopenjdk
+brew install --cask temurin
 brew install graphviz
 ```
 


### PR DESCRIPTION
The [`adoptopenjdk` brew cask is deprecated and no-longer updated since 2021-08-01](https://github.com/AdoptOpenJDK/homebrew-openjdk/blob/f6e8c971c98f5ba48aedf2a5d218ebc914ee2304/README.md#L1,L2).

The [`adoptopenjdk` team recommend switching to the, homebrew maintained, temurin cask instead](https://github.com/AdoptOpenJDK/homebrew-openjdk#-deprecation-notice-).

This PR is a small documentation update to reflect the new recommendation