### PR TITLE
mod: syntax highlighting: Improve syntax highlighting - Add some keywords

### DIFF
--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$

--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$


### PR DESCRIPTION
To continue #425, #452 and #454:

Mod:
- Add `goto` keyword (on `line begin keywords`)
- Add [timing's](https://plantuml.com/en/timing-diagram) keyword (on `line begin keywords`):
  - binary
  - clock
  - concise
  - robust