### PR TITLE
add btn for copy preview image to clipboard.

### DIFF
--- a/templates/js/zoom.js
+++ b/templates/js/zoom.js
@@ -35,6 +35,9 @@ class Zoom {
         document.getElementById("btnZoomOut").addEventListener("click", () => {
             this.smoothZomm(this.status.zoom / 1.2, this.getWindowCenterMousePointer());
         });
+        document.getElementById("btnCopy").addEventListener("click", () => {
+            this.copyImage(this.img);
+        });
         document.getElementById("btnZoomToggle").addEventListener("click", () => {
             if (this.isImageExpanded()) {
                 resetZoom();
@@ -266,5 +269,27 @@ class Zoom {
     }
     isImageExpanded() {
         return this.iconToggle.innerText == "fullscreen_exit";
+    }
+    copyImage(img){
+        var reg = /width:(\d+)px;height:(\d+)px;/
+        let [_, width, height] = atob(img.src.substr(26)).match(reg);
+        var canvas = document.createElement( "canvas" );
+        document.body.appendChild(canvas);
+        canvas.width = width
+        canvas.height = height
+        var ctx = canvas.getContext( "2d" );
+        ctx.drawImage(img, 0, 0);
+        showTip("Copying...", 500);
+        canvas.toBlob(function (blob) {
+            showTip("Copying...", 500);
+            let data = [new ClipboardItem({ [blob.type]: blob })];
+            navigator.clipboard.write(data).then(function () {
+                console.log('success')
+                showTip("Copy to clipboard.", 2000);
+            }, function (err) {
+                showTip("Copy to clipboard error.", 3000);
+                console.log('Copy to clipboard error.', err)
+            })
+        }, 1);
     }
 }

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -56,6 +56,9 @@
             <button class="btn" id="btnZoomIn">
                 <i class="material-icons">zoom_in</i>
             </button>
+            <button class="btn" id="btnCopy">
+                <i class="material-icons">content_copy</i>
+            </button>
             <button class="btn" id="btnHelp">
                 <i class="material-icons">help</i>
             </button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18745376/145985103-bca0b6a9-1560-4e59-bbd1-4bd3e60a04d0.png)
Because the built-in copy operation on the page is not available, a button for copying images has been added to facilitate sharing pictures without saving them locally. It may not conform to previous code styles. Please understand.