### PR TITLE
[Fix] Getting "Error: 414 URI Too Long" until restart of vscode

### DIFF
--- a/src/plantuml/renders/plantumlServer.ts
+++ b/src/plantuml/renders/plantumlServer.ts
@@ -10,6 +10,7 @@ interface Dictionary<T> {
     [key: string]: T;
 }
 let noPOSTServers: Dictionary<boolean> = {};
+let POSTSupportiveServers: Dictionary<boolean> = {};
 
 class PlantumlServer implements IRender {
     /**
@@ -53,9 +54,10 @@ class PlantumlServer implements IRender {
                     return httpWrapper("GET", server, diagram, format, index, savePath2);
                 } else {
                     return httpWrapper("POST", server, diagram, format, index, savePath2)
+                        .then(() => POSTSupportiveServers[server] = true)
                         .catch(
                             err => {
-                                if (err instanceof HTTPError && err.isResponeError) {
+                                if (err instanceof HTTPError && err.isResponeError && !POSTSupportiveServers[server]) {
                                     // do not retry POST again, if the server gave unexpected respone
                                     noPOSTServers[server] = true
                                     // fallback to GET


### PR DESCRIPTION
Not falling back to using GET requests to a server in case an initial POST request to the same server was successful. The GET method will be picked only in case the first POST call was failed for any reason.

[Issue](https://github.com/qjebbs/vscode-plantuml/issues/396)