### PR TITLE
upd: fix some typo and add some ref on `ChangeLog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,20 @@
 ## 2.17.2
 
 - Not fallback to get if post was at least once successful, **@z77ma**, [#470](https://github.com/qjebbs/vscode-plantuml/pull/470)
-- Update translations
+- Update translations, [#467](https://github.com/qjebbs/vscode-plantuml/pull/467)
 - Update embedded jar to 1.2022.0
 
 ## 2.17.0
 
 - Add ability to copy image in preview, [#462](https://github.com/qjebbs/vscode-plantuml/pull/462)
-- Update syntax highlighting
+- Update syntax highlighting, [#457](https://github.com/qjebbs/vscode-plantuml/pull/457)
 - Update embedded jar to 1.2021.16
 
 ## 2.16.1
 
 - Add setting `plantuml.lintDiagramNoName`
-- Fix plantuml fence detect ([#455](https://github.com/qjebbs/vscode-plantuml/issues/455)
-- Update syntax highlighting
+- Fix plantuml fence detect ([#455](https://github.com/qjebbs/vscode-plantuml/issues/455))
+- Update syntax highlighting ([#454](https://github.com/qjebbs/vscode-plantuml/pull/454))
 - Update embedded jar to 1.2021.14
 
 ## 2.16.0
@@ -26,6 +26,7 @@
 - Update syntax highlighting ([#419](https://github.com/qjebbs/vscode-plantuml/pull/419), [#425](https://github.com/qjebbs/vscode-plantuml/pull/425))
 - Toggle Block Comment configuration ([#420](https://github.com/qjebbs/vscode-plantuml/pull/420))
 - Update readme ([#446](https://github.com/qjebbs/vscode-plantuml/pull/446))
+
 ## 2.15.1
 
 - Fix: Error in console while typing include ([#412](https://github.com/qjebbs/vscode-plantuml/issues/412))
@@ -35,7 +36,7 @@
 
 - Improvement: Adopt to VSCode Workspace Trust
 - Improvement: Ignore "Picked up" java stderr messages ([#391](https://github.com/qjebbs/vscode-plantuml/issues/391))
-- Improvement: Add ```puml rendering support in the md file ([#397](https://github.com/qjebbs/vscode-plantuml/issues/397))
+- Improvement: Add` ```puml rendering` support in the md file ([#397](https://github.com/qjebbs/vscode-plantuml/issues/397))
 - Fix: Some machine-overridable scope settings not applied from workspace
 
 ## 2.14.5


### PR DESCRIPTION
Fix some typo and add some ref on `ChangeLog`:
- add some `)`
- add some ref to 'Update syntax highlighting'
- add newline for §2.15.1