### PR TITLE
mod: syntax highlighting: Improve syntax highlighting - Add some keywords (`remove`, `compact`, ...)

### DIFF
--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust|compact\s+concise|compact\s+robust|json)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$

--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,7 +90,7 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust|compact\s+concise|compact\s+robust|json)\b
+      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust|compact\s+concise|compact\s+robust|json|protocol|struct)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
       match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$

--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -351,8 +351,8 @@ repository:
           '1': {name: storage.modifier.class.fields.source.wsd}
           '3': {name: keyword.other.class.fields.source.wsd}
           '4': {name: string.quoted.double.class.other.source.wsd}
-    - comment: hide & show
-      match: (?i)^\s*(hide|show)\s+(([\w\d_\.]+|"[^"]+")|<<.+?>>|Stereotypes|class|interface|enum)(\s+(empty fields|empty methods|fields|attributes|methods|members|circle))?\s*$
+    - comment: hide & show & remove
+      match: (?i)^\s*(hide|show|remove)\s+(([\w\d_\.\$]+|"[^"]+")|<<.+?>>|Stereotypes|class|interface|enum|@unlinked)(\s+(empty fields|empty attributes|empty methods|empty description|fields|attributes|methods|members|circle))?\s*$
       captures:
         '1': {name: keyword.other.class.hideshow.source.wsd}
         '2': {name: support.variable.class.hideshow.source.wsd}


### PR DESCRIPTION
To continue #425, #452, #454 and #457:

Add on `hide & show` section:
- `remove` 
- `empty description`
- `@unlinked`
- `$tag`

Add on `line begin keywords`:
- `json`
- `compact` 
- [ ] _[TODO: `mode compact`]_