### PR TITLE
Fix child processes killing function

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,13 +371,13 @@
     "buildsyntax": "node ./scripts/build-syntax.js"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.40",
-    "@types/vscode": "^1.57.0",
+    "@types/mocha": "*",
+    "@types/node": "*",
+    "@types/vscode": "*",
     "js-yaml": "^3.13.1",
     "markdown-it": "^8.3.2",
     "plist": "^3.0.2",
-    "typescript": "^3.7.2"
+    "typescript": "*"
   },
   "dependencies": {
     "linq-collections": "*",

--- a/src/plantuml/renders/httpWrapper.ts
+++ b/src/plantuml/renders/httpWrapper.ts
@@ -74,9 +74,9 @@ export function httpWrapper(method: string, server: string, diagram: Diagram, fo
                 resolve(body);
             } else if (response.headers['x-plantuml-diagram-error']) {
                 let msg = parsePlantumlError(
-                    response.headers['x-plantuml-diagram-error'],
-                    parseInt(response.headers['x-plantuml-diagram-error-line']),
-                    response.headers['x-plantuml-diagram-description'],
+                    response.headers['x-plantuml-diagram-error'] as string,
+                    parseInt(response.headers['x-plantuml-diagram-error-line'] as string),
+                    response.headers['x-plantuml-diagram-description'] as string,
                     diagram
                 );
                 reject(<RenderError>{ error: msg, out: body });

--- a/src/plantuml/renders/local.ts
+++ b/src/plantuml/renders/local.ts
@@ -110,6 +110,7 @@ class LocalRender implements IRender {
                 // Add user jar args
                 params.push(...config.jarArgs(diagram.parentUri));
                 let process : any = child_process.spawn(config.java(diagram.parentUri), params);
+                console.log(`Process ${process.pid} spawned`);
                 processes.push(process);
                 return pChain.then(
                     () => {

--- a/src/plantuml/renders/local.ts
+++ b/src/plantuml/renders/local.ts
@@ -110,7 +110,6 @@ class LocalRender implements IRender {
                 // Add user jar args
                 params.push(...config.jarArgs(diagram.parentUri));
                 let process : any = child_process.spawn(config.java(diagram.parentUri), params);
-                console.log(`Process ${process.pid} spawned`);
                 processes.push(process);
                 return pChain.then(
                     () => {

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -119,11 +119,15 @@ class Previewer extends vscode.Disposable {
     }
     private killTask(process: child_process.ChildProcess) {
         return new Promise((resolve, reject) => {
-            process.kill('SIGINT');
-            process.on('exit', (code) => {
-                // console.log(`killed ${process.pid} with code ${code}!`);
+            process.on('exit', (code, sig) => {
+                console.log(`Killed ${process.pid} with code ${code} and signal ${sig}!`);
                 resolve(true);
             });
+            
+            if(!process.kill('SIGINT') && process.exitCode != null){
+                console.log(`Process ${process.pid} exited with status code ${process.exitCode}`);
+                resolve(true);
+            }
         })
     }
     get TargetChanged(): boolean {

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -120,12 +120,12 @@ class Previewer extends vscode.Disposable {
     private killTask(process: child_process.ChildProcess) {
         return new Promise((resolve, reject) => {
             process.on('exit', (code, sig) => {
-                console.log(`Killed ${process.pid} with code ${code} and signal ${sig}!`);
+                // console.log(`Killed ${process.pid} with code ${code} and signal ${sig}!`);
                 resolve(true);
             });
             
             if(!process.kill('SIGINT') && process.exitCode != null){
-                console.log(`Process ${process.pid} exited with status code ${process.exitCode}`);
+                // console.log(`Process ${process.pid} exited with status code ${process.exitCode}`);
                 resolve(true);
             }
         })


### PR DESCRIPTION
If a process exits (either normally or due to an error) before the call to `process.kill('SIGINT')` inside function `killTask`, then the signal cannot be delivered to the process, and the handler registered on 'exit' event for the process won't be executed, thus leaving the promise unresolved, and therefore the extension gets stuck.

To solve this, check the value returned by `process.kill('SIGINT')`:
- If that's `true`, then the signal is delivered, and the 'exit' event handler should be executed;
- If that 's `false`, then the signal cannot be delivered. Then, check the `exitCode` of the process. If that is not `null`, then the process already exited, therefore there is nothing more to do than resolve the returned promise.

Note that **theoretically**, in case the call to `process.kill('SIGINT')` returns false, then the `exitCode` of the process should be necessarily not null.
So, the conditional check for the value of `exitCode` should be quite redundant, but it allows to easily fix function's behavior in case the above assumption is false.

This should fix issue #360 and related issues.