### PR TITLE
add preview button to PlantUML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       {
         "command": "plantuml.preview",
         "title": "%plantuml.preview.title%",
-        "category": "PlantUML"
+        "category": "PlantUML",
+        "icon": "$(open-preview)"
       },
       {
         "command": "plantuml.URLCurrent",
@@ -137,6 +138,13 @@
         {
           "command": "plantuml.exportWorkspace",
           "group": "PlantUML"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "editorLangId == plantuml",
+          "command": "plantuml.preview",
+          "group": "navigation"
         }
       ]
     },


### PR DESCRIPTION
similar to markdown, rst and other extentions, we now also show the $(open-preview) icon on PlantUML files. This is much more inline with generall vscode behavior and should help users to seamlessly change between extentions

Looks like this:

![image](https://user-images.githubusercontent.com/62838959/206749966-96985edc-6f5a-424d-ae95-6f31b789be1b.png)


closes #431