### PR TITLE
 Rules for syntax highlighting  and formatting of switch statements in activity diagrams

### DIFF
--- a/src/plantuml/formatRules.ts
+++ b/src/plantuml/formatRules.ts
@@ -119,6 +119,26 @@ let rules = <RulesWriting>{
                     }
                 },
                 {
+                    comment: "block switch-case",
+                    isBlock: true,
+                    begin: /{{LB}}switch\s*\(.*?\){{LE}}/i,
+                    again: /{{LB}}case\s*\(.*?\){{LE}}/i,
+                    end: /{{LB}}endswitch{{LE}}/i,
+                    beginCaptures: {
+                        0: ElementType.asIs,
+                    },
+                    againCaptures: {
+                        0: ElementType.asIs,
+                    },
+                    endCaptures: {
+                        0: ElementType.word,
+                    },
+                    patterns: {
+                        includes: ["Quoted", "Block"],
+                    }
+                },
+
+                {
                     comment: "block split fork",
                     isBlock: true,
                     begin: /{{LB}}(split|fork){{LE}}/i,

--- a/syntaxes/plantuml.yaml-tmLanguage
+++ b/syntaxes/plantuml.yaml-tmLanguage
@@ -90,10 +90,10 @@ repository:
     patterns:
     - comment: line begin keywords
       name: keyword.other.linebegin.source.wsd
-      match: (?i)^\s*(usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust|compact\s+concise|compact\s+robust|json|protocol|struct)\b
+      match: (?i)^\s*(switch|case|usecase|actor|object|participant|boundary|control|entity|database|create|component|interface|package|node|folder|frame|cloud|annotation|enum|abstract\s+class|abstract|class|state|autonumber(\s+stop|\s+resume|\s+inc)?|activate|deactivate|return|destroy|newpage|alt|else|opt|loop|par|break|critical|group|box|rectangle|namespace|partition|agent|artifact|card|circle|collections|file|hexagon|label|person|queue|stack|storage|mainframe|map|repeat|backward|diamond|goto|binary|clock|concise|robust|compact\s+concise|compact\s+robust|json|protocol|struct)\b
     - comment: whole line keywords
       name: keyword.other.wholeline.source.wsd
-      match: (?i)^\s*(split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$
+      match: (?i)^\s*(endswitch|split( again)?|endif|repeat|start|stop|end|end\s+fork|end\s+split|fork( again)?|detach|end\s+box|top\s+to\s+bottom\s+direction|left\s+to\s+right\s+direction|kill|end\s+merge|allow(_)?mixing)\s*$
     - comment: other keywords
       name: keyword.other.other.source.wsd
       match: (?i)\b(as|{(static|abstract)\})\b


### PR DESCRIPTION
I am aware the formatter is deprecated, but it is nevertheless very useful to me.
I was missing the handling of the switch statement, so here it is.