### PR TITLE
[Bugfix] Skip workspace folders where no diagramsRoot folder exist

### DIFF
--- a/src/plantuml/exporter/exportWorkSpace.ts
+++ b/src/plantuml/exporter/exportWorkSpace.ts
@@ -50,14 +50,10 @@ async function getFileList(para?): Promise<FileAndFormat[]> {
 
     if (!para) {
         for (let folder of vscode.workspace.workspaceFolders) {
-            const path = config.diagramsRoot(folder.uri));
-            if (fs.existsSync(path)) {
-                _files.push(...await getFileList(path);
+            const path = config.diagramsRoot(folder.uri);
+            if (fs.existsSync(path.fsPath)) {
+                _files.push(...await getFileList(path));
             }
-            else {
-                console.log(`Skipping - Does not exist: {path}`);
-            }
-            
         }
     } else if (para instanceof Array) {
         for (let u of para.filter(p => p instanceof vscode.Uri)) {

--- a/src/plantuml/exporter/exportWorkSpace.ts
+++ b/src/plantuml/exporter/exportWorkSpace.ts
@@ -50,7 +50,14 @@ async function getFileList(para?): Promise<FileAndFormat[]> {
 
     if (!para) {
         for (let folder of vscode.workspace.workspaceFolders) {
-            _files.push(...await getFileList(config.diagramsRoot(folder.uri)));
+            const path = config.diagramsRoot(folder.uri));
+            if (fs.existsSync(path)) {
+                _files.push(...await getFileList(path);
+            }
+            else {
+                console.log(`Skipping - Does not exist: {path}`);
+            }
+            
         }
     } else if (para instanceof Array) {
         for (let u of para.filter(p => p instanceof vscode.Uri)) {


### PR DESCRIPTION
I have a project where I use your extension to generate my diagrams. It is really convenient. Thanks for developing it <3

My project contains several workspace folders, but my documentation is only located in the one folder. This leads to a crash:
`Error: ENOENT: no such file or directory, stat '<workspace_folder>\<diagramsRoot>'`

It is the same issue referred to here: #414 

This PR adds a simple check to only search for diagrams if the `diagramsRoot` exists in the workspace folder.

It is currently only possible to check the entire project for diagrams by leaving `diagramsRoot` empty, but my repo is large and it takes a minute to scan. I'd really love to have this small improvement as it would speed up my workflow.

Cheers,
Sin