### PR TITLE
Removed forced white background

### DIFF
--- a/src/markdown-it-plantuml/render.ts
+++ b/src/markdown-it-plantuml/render.ts
@@ -19,7 +19,7 @@ export function renderHtml(tokens: markdowIt.Token[], idx: number) {
         result.urls.reduce((p, url) => {
             p += renderAsObject ?
                 `\n<object type="${mimeType}" data="${url}"></object>` : // work with markdown extended export, solve #253
-                `\n<img style="background-color:#FFF;" src="${url}">`;  // work with preview, solve #258
+                `\n<img src="${url}">`;  // work with preview, solve #258
             return p;
         }, "") :
         `\n<pre><code><code>⚠️${localize(53, null)}\n\n${diagram.content}</code></code></pre>`;


### PR DESCRIPTION
When using 

```plantuml
skinparam backgroundColor transparent
```

the Markdown Preview still shows white background. This is because it was forced in the stylesheet of the rendered HTML image.

Should fix #530 #589.
And kind of #52.

This reverts #257 1d59090 as the background for the markdown preview should not be handled by this plugin IMHO