### PR TITLE
Exclude .iuml files from diagram name linting

### DIFF
--- a/src/plantuml/diagram/diagram.ts
+++ b/src/plantuml/diagram/diagram.ts
@@ -13,6 +13,7 @@ export class Diagram {
     parentUri: vscode.Uri;
     path: string;
     fileName: string;
+    fileExt: string;
     dir: string;
     content: string;
     start: vscode.Position;
@@ -37,6 +38,7 @@ export class Diagram {
         this.parentUri = this.document.uri;
         this.path = this.document.uri.fsPath;
         this.fileName = path.basename(this.path);
+        this.fileExt = path.extname(this.path);
         let i = this.fileName.lastIndexOf(".");
         if (i >= 0) this.fileName = this.fileName.substr(0, i);
         this.dir = path.dirname(this.path);

--- a/src/providers/diagnoser.ts
+++ b/src/providers/diagnoser.ts
@@ -34,7 +34,7 @@ export class Diagnoser extends vscode.Disposable {
         let names = {};
         diagrams.map(d => {
             let range = document.lineAt(d.start.line).range;
-            if (config.lintDiagramNoName(d.parentUri) && !d.nameRaw) {
+            if (config.lintDiagramNoName(d.parentUri) && d.fileExt !== '.iuml' && !d.nameRaw) {
                 diagnostics.push(
                     new vscode.Diagnostic(
                         range,


### PR DESCRIPTION
This PR fixes an issue where the linter was incorrectly flagging diagrams in `.iuml` (include) files for not having a name.

**Changes**
- Added `fileExt` property to the `Diagram` class to track the file extension
- Modified the diagnoser to skip the "diagram without name" lint check for `.iuml` files

**Rationale**
Include files (`.iuml`) are typically used for reusable components and don't require diagram names, so linting them for missing names creates unnecessary noise.