### PR TITLE
Add "Show Diagram Source" Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "onCommand:plantuml.preview",
     "onCommand:plantuml.URLCurrent",
     "onCommand:plantuml.URLDocument",
-    "onCommand:plantuml.extractSource"
+    "onCommand:plantuml.extractSource",
+    "onCommand:plantuml.showSource"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -104,6 +105,12 @@
         "command": "plantuml.extractSource",
         "title": "%plantuml.extractSource.title%",
         "category": "PlantUML"
+      },
+      {
+        "command": "plantuml.showSource",
+        "title": "%plantuml.showSource.title%",
+        "category": "PlantUML",
+        "icon": "$(go-to-file)"
       }
     ],
     "menus": {
@@ -144,6 +151,11 @@
         {
           "when": "editorLangId == plantuml",
           "command": "plantuml.preview",
+          "group": "navigation"
+        },
+        {
+          "when": "activeWebviewPanelId == plantuml.preview",
+          "command": "plantuml.showSource",
           "group": "navigation"
         }
       ]

--- a/package.nls.da.json
+++ b/package.nls.da.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "Generér URL for aktuelt diagram",
 	"plantuml.URLDocument.title": "Generér URL'er til diagrammer i aktuel fil",
 	"plantuml.extractSource.title": "Udtræk PlantUML diagramkilde fra billede",
+	"plantuml.showSource.title": "Vis diagramkilde",
 	"plantuml.configuration.configTitle": "PlantUML konfiguration",
 	"plantuml.configuration.exportFormat": "Eksporteringsformat. Lad være blankt for at vælge format hver gang.",
 	"plantuml.configuration.jar": "Alternativ sti til plantuml.jar. Lad være blankt for at bruge integreret jar.",

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "URL für das aktuelle Diagramm generieren",
 	"plantuml.URLDocument.title": "URLs für die Diagramme der aktuellen Datei generieren",
 	"plantuml.extractSource.title": "Extract PlantUML Diagram Source from Image",
+	"plantuml.showSource.title": "Diagrammquelle anzeigen",
 	"plantuml.configuration.configTitle": "PlantUML configuration",
 	"plantuml.configuration.exportFormat": "Exportformat. Lassen Sie es leer, dann können Sie das Format bei jedem Export auswählen.",
 	"plantuml.configuration.jar": "Alternativer plantuml.jar Speicherort. Lassen Sie es leer, um die integrierte jar zu verwenden.",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -6,6 +6,7 @@
   "plantuml.URLCurrent.title": "Generar URL para el Diagrama Atual",
   "plantuml.URLDocument.title": "Generar URLs para los Diagramas del Archivo Actual",
   "plantuml.extractSource.title": "Extraer Código de PlantUML a Partir de Imagen",
+  "plantuml.showSource.title": "Mostrar Código Fuente del Diagrama",
   "plantuml.configuration.configTitle": "Configuración de PlantUML",
   "plantuml.configuration.exportFormat": "Formato de Exportación. Dejar en blanco para escoger formato durante cada exportación.",
   "plantuml.configuration.jar": "Ubicación alternativa de plantuml.jar. Dejar en blanco para usar el jar integrado.",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "Générer l'URL du diagramme en cours",
 	"plantuml.URLDocument.title": "Générer les URLs des diagrammes du fichier",
 	"plantuml.extractSource.title": "Extraire la source du diagramme PlantUML à partir de l'image",
+	"plantuml.showSource.title": "Afficher la source du diagramme",
 	"plantuml.configuration.configTitle": "Configuration de PlantUML",
 	"plantuml.configuration.exportFormat": "Format d'export. Laissez vide pour sélectionner le format à chaque export.",
 	"plantuml.configuration.jar": "Chemin pour utiliser un autre plantuml.jar. Laissez vide pour utiliser le jar intégré.",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "カーソル位置のダイアグラムをURLに変換",
 	"plantuml.URLDocument.title": "ファイル内のダイアグラムをURLに変換",
 	"plantuml.extractSource.title": "画像からPlantUMLダイアグラムのソースを抽出",
+	"plantuml.showSource.title": "ダイアグラムのソースを表示",
 	"plantuml.configuration.configTitle": "PlantUML設定",
 	"plantuml.configuration.exportFormat": "エクスポートのフォーマット指定。空白の場合はエクスポート実行ごとにフォーマットを選択します",
 	"plantuml.configuration.jar": "代替の plantuml.jar の位置を指定。 空白の場合は組み込みのjarファイルを使用します",

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "Generate URL for Current Diagram",
 	"plantuml.URLDocument.title": "Generate URLs for Current File Diagrams",
 	"plantuml.extractSource.title": "Extract PlantUML Diagram Source from Image",
+	"plantuml.showSource.title": "Show Diagram Source",
 	"plantuml.configuration.configTitle": "PlantUML configuration",
 	"plantuml.configuration.exportFormat": "Export format. Leave it blank to pick format everytime you export.",
 	"plantuml.configuration.jar": "Alternate plantuml.jar location. Leave it blank to use integrated jar.",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "현재 다이어그램에 대한 URL 생성하기",
 	"plantuml.URLDocument.title": "현재 다이어그램 파일에 대한 URL 생성하기",
 	"plantuml.extractSource.title": "그림에서 PlantUML 다이어그램 소스 추출하기",
+	"plantuml.showSource.title": "다이어그램 소스 보기",
 	"plantuml.configuration.configTitle": "PlantUML 환경설정",
 	"plantuml.configuration.exportFormat": "내보내기 형식. 매번 내보낼 때마다 선택하려면 비워두십시오.",
 	"plantuml.configuration.jar": "plantuml.jar의 다른 위치. 통합 jar를 쓰려면 비워두십시오.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "Сгенерировать URL для текущей диаграммы",
 	"plantuml.URLDocument.title": "Сгенерировать URL пути для диаграмм в файле",
 	"plantuml.extractSource.title": "Извлечь исходник PlantUML из картинки",
+	"plantuml.showSource.title": "Показать исходный код диаграммы",
 	"plantuml.configuration.configTitle": "Настройка PlantUML",
 	"plantuml.configuration.exportFormat": "Формат экспорта. Оставьте пустым, если хотите выбирать формат при каждом экспорте.",
 	"plantuml.configuration.jar": "Альтернативный путь к plantuml.jar. Оставьте пустым, если хотите использовать встроенную библиотеку.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "为光标位置图表创建链接",
 	"plantuml.URLDocument.title": "为当前文件图表创建链接",
 	"plantuml.extractSource.title": "从图片中提取 PlantUML 图表源码",
+	"plantuml.showSource.title": "显示图表源码",
 	"plantuml.configuration.configTitle": "PlantUML 配置",
 	"plantuml.configuration.exportFormat": "导出格式。若留空，则在每次导出时选择格式。",
 	"plantuml.configuration.jar": "自定义 plantuml.jar 的位置。留空则使用内置的版本。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -6,6 +6,7 @@
 	"plantuml.URLCurrent.title": "為當前圖表產生URL鏈接",
 	"plantuml.URLDocument.title": "為當前檔案圖表產生URL鏈接",
 	"plantuml.extractSource.title": "從圖片中擷取 PlantUML 原始碼",
+	"plantuml.showSource.title": "顯示圖表原始碼",
 	"plantuml.configuration.configTitle": "PlantUML 設定",
 	"plantuml.configuration.exportFormat": "匯出格式。 若爲空，則在每次匯出的時候選擇格式。",
 	"plantuml.configuration.jar": "自定 plantuml.jar 的位置。留空則使用套件的版本。",

--- a/src/commands/showSource.ts
+++ b/src/commands/showSource.ts
@@ -1,0 +1,12 @@
+import { previewer } from "../providers/previewer";
+import { Command } from "./common";
+
+export class CommandShowSource extends Command {
+    constructor() {
+        super("plantuml.showSource");
+    }
+
+    async execute() {
+        await previewer.showSource();
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { CommandURLDocument } from './commands/urlDocument';
 import { CommandExtractSource } from './commands/extractSource';
 import { plantumlPlugin } from './markdown-it-plantuml/index';
 import { Diagnoser } from './providers/diagnoser';
+import { CommandShowSource } from './commands/showSource';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -39,6 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
             new CommandURLCurrent(),
             new CommandURLDocument(),
             new CommandExtractSource(),
+            new CommandShowSource(),
             new Formatter(),
             new Symbol(),
             new Completion(),

--- a/src/plantuml/diagram/diagram.ts
+++ b/src/plantuml/diagram/diagram.ts
@@ -17,6 +17,7 @@ export class Diagram {
     content: string;
     start: vscode.Position;
     end: vscode.Position;
+    viewColumn: vscode.ViewColumn;
     private _lines: string[] = undefined;
     private _type: DiagramType = undefined;
     private _nameRaw: string = undefined;
@@ -26,7 +27,7 @@ export class Diagram {
     private _contentWithInclude: string = undefined;
 
     constructor(content: string);
-    constructor(content: string, document: vscode.TextDocument, start: vscode.Position, end: vscode.Position);
+    constructor(content: string, document: vscode.TextDocument, start: vscode.Position, end: vscode.Position, viewColumn?: vscode.ViewColumn);
     constructor(content: string, ...para: any[]) {
         this.content = content;
         if (!para || para.length < 3)
@@ -34,6 +35,7 @@ export class Diagram {
         this.document = para[0];
         this.start = para[1];
         this.end = para[2];
+        if (para.length >= 3) this.viewColumn = para[3];
         this.parentUri = this.document.uri;
         this.path = this.document.uri.fsPath;
         this.fileName = path.basename(this.path);

--- a/src/plantuml/diagram/tools.ts
+++ b/src/plantuml/diagram/tools.ts
@@ -4,12 +4,12 @@ import { languageid } from '../common';
 
 export function currentDiagram(): Diagram {
     let editor = vscode.window.activeTextEditor;
-    if (editor) return diagramAt(editor.document, editor.selection.anchor.line);
+    if (editor) return diagramAt(editor.document, editor.selection.anchor.line, editor.viewColumn);
 }
 
-export function diagramAt(document: vscode.TextDocument, lineNumber: number): Diagram
-export function diagramAt(document: vscode.TextDocument, position: vscode.Position): Diagram
-export function diagramAt(document: vscode.TextDocument, para: number | vscode.Position): Diagram {
+export function diagramAt(document: vscode.TextDocument, lineNumber: number, viewColumn?: vscode.ViewColumn): Diagram
+export function diagramAt(document: vscode.TextDocument, position: vscode.Position, viewColumn?: vscode.ViewColumn): Diagram
+export function diagramAt(document: vscode.TextDocument, para: number | vscode.Position, viewColumn?: vscode.ViewColumn): Diagram {
     let lineNumber = para instanceof vscode.Position ? para.line : para;
     let start: vscode.Position;
     let end: vscode.Position;
@@ -44,23 +44,23 @@ export function diagramAt(document: vscode.TextDocument, para: number | vscode.P
     let diagram: Diagram = undefined;
     if (start && end) {
         content = document.getText(new vscode.Range(start, end));
-        diagram = new Diagram(content, document, start, end);
+        diagram = new Diagram(content, document, start, end, viewColumn);
     }
     return diagram;
 }
 
-export function diagramsOf(document: vscode.TextDocument): Diagram[] {
+export function diagramsOf(document: vscode.TextDocument, viewColumn?: vscode.ViewColumn): Diagram[] {
     let diagrams: Diagram[] = [];
     for (let i = 0; i < document.lineCount; i++) {
         let line = document.lineAt(i);
         if (diagramStartReg.test(line.text)) {
-            let d = diagramAt(document, i);
+            let d = diagramAt(document, i, viewColumn);
             if (d) diagrams.push(d);
         }
     }
     // if no diagram block found, try add entire document
     if (!diagrams.length) {
-        let d = diagramAt(document, 0);
+        let d = diagramAt(document, 0, viewColumn);
         if (d) diagrams.push(d);
     }
     return diagrams;

--- a/src/plantuml/exporter/exportDocument.ts
+++ b/src/plantuml/exporter/exportDocument.ts
@@ -28,7 +28,7 @@ export async function exportDocument(all: boolean) {
     }
     let diagrams: Diagram[] = [];
     if (all) {
-        diagrams = diagramsOf(editor.document);
+        diagrams = diagramsOf(editor.document, editor.viewColumn);
         if (!diagrams.length) {
             vscode.window.showInformationMessage(localize(2, null));
             return;

--- a/src/plantuml/urlMaker/urlDocument.ts
+++ b/src/plantuml/urlMaker/urlDocument.ts
@@ -25,7 +25,7 @@ export async function makeDocumentURL(all: boolean) {
     }
     let diagrams: Diagram[] = [];
     if (all) {
-        diagrams = diagramsOf(editor.document);
+        diagrams = diagramsOf(editor.document, editor.viewColumn);
         if (!diagrams.length) {
             vscode.window.showWarningMessage(localize(15, null));
             return;

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -80,18 +80,15 @@ class Previewer extends vscode.Disposable {
         this.error = "";
     }
 
-    private get TargetChanged(): boolean {
-        let current = currentDiagram();
-        if (!current) return false;
-        let changed = (!this.rendered || !this.rendered.isEqual(current));
-        if (changed) {
-            this.rendered = current;
-            this.error = "";
-            this.images = [];
-            this.imageError = "";
-            this.previewPageStatus = "";
-        }
-        return changed;
+    private targetChanged(diagram: Diagram): boolean {
+        if (!diagram) return false;
+        if (!this.rendered) return true;
+        return !this.rendered.isEqual(diagram);
+    }
+
+    private updateTarget(diagram: Diagram) {
+        this.reset();
+        this.rendered = diagram;
     }
 
     private async update(processingTip: boolean) {
@@ -110,6 +107,9 @@ class Previewer extends vscode.Disposable {
             this.images = [];
             this.updateWebView();
             return;
+        }
+        if (this.targetChanged(diagram)) {
+            this.updateTarget(diagram);
         }
         let task: RenderTask = exportToBuffer(diagram, "svg");
         this.task = task;
@@ -231,9 +231,9 @@ class Previewer extends vscode.Disposable {
                 if (!diagrams.length) return;
 
                 //reset in case that starting commnad in none-diagram area,
-                //or it may show last error image and may cause wrong "TargetChanged" result on cursor move.
+                //or it may show last error image and may cause wrong "targetChanged" result on cursor move.
                 this.reset();
-                this.TargetChanged;
+
                 //update preview
                 await this.update(true);
             } catch (error) {
@@ -284,7 +284,8 @@ class Previewer extends vscode.Disposable {
             lastTimestamp = new Date().getTime();
             setTimeout(() => {
                 if (new Date().getTime() - lastTimestamp >= 400) {
-                    if (!this.TargetChanged) return;
+                    const diagram = currentDiagram();
+                    if (!this.targetChanged(diagram)) return;
                     this.update(true);
                 }
             }, 500);

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -43,71 +43,6 @@ class Previewer extends vscode.Disposable {
         this.watchDisposables && this.watchDisposables.length && this.watchDisposables.map(d => d.dispose());
     }
 
-    reset() {
-        this.rendered = null;
-        this.previewPageStatus = "";
-        this.images = [];
-        this.imageError = "";
-        this.error = "";
-    }
-
-    updateWebView(): string {
-        let env = {
-            localize: localize,
-            images: this.images.reduce((p, c) => {
-                if (c.startsWith('data:image/')) {
-                    return `${p}<img src="${c}">`
-                } else {
-                    return `${p}${c.replaceAll('<area ', '<area target="_blank"')}`
-                }
-            }, ""),
-            imageError: "",
-            error: "",
-            status: this.previewPageStatus,
-            // nonce: Math.random().toString(36).substr(2),
-            icon: "file:///" + path.join(extensionPath, "images", "icon.png"),
-            settings: JSON.stringify({
-                zoomUpperLimit: this.zoomUpperLimit,
-                showSpinner: this.status === previewStatus.processing,
-                showSnapIndicators: config.previewSnapIndicators,
-                swapMouseButtons: config.previewSwapMouseButtons,
-            }),
-        };
-        try {
-            switch (this.status) {
-                case previewStatus.default:
-                case previewStatus.error:
-                    env.imageError = this.imageError;
-                    env.error = this.error.replace(/\n/g, "<br />");
-                    this._uiPreview.show("preview.html", env);
-                    break;
-                case previewStatus.processing:
-                    env.error = "";
-                    env.images = ["svg", "png"].reduce((p, c) => {
-                        if (p) return p;
-                        let exported = calculateExportPath(this.rendered, c);
-                        exported = addFileIndex(exported, 0, this.rendered.pageCount);
-                        return fs.existsSync(exported) ? env.images = `<img src="${fileToBase64(exported)}">` : "";
-                    }, "");
-                    this._uiPreview.show("preview.html", env);
-                    break;
-                default:
-                    break;
-            }
-        } catch (error) {
-            return error
-        }
-    }
-    setUIStatus(status: string) {
-        this.previewPageStatus = status;
-    }
-    async update(processingTip: boolean) {
-        if (this.taskKilling) return;
-        await this.killTasks();
-        // console.log("updating...");
-        // do not await doUpdate, so that preview window could open before update task finish.
-        this.doUpdate(processingTip).catch(e => showMessagePanel(e));
-    }
     private killTasks() {
         if (!this.task) return;
         this.task.canceled = true;
@@ -122,20 +57,30 @@ class Previewer extends vscode.Disposable {
             this.taskKilling = false;
         });
     }
+
     private killTask(process: child_process.ChildProcess) {
         return new Promise((resolve, reject) => {
             process.on('exit', (code, sig) => {
                 // console.log(`Killed ${process.pid} with code ${code} and signal ${sig}!`);
                 resolve(true);
             });
-            
+
             if(!process.kill('SIGINT') && process.exitCode != null){
                 // console.log(`Process ${process.pid} exited with status code ${process.exitCode}`);
                 resolve(true);
             }
         })
     }
-    get TargetChanged(): boolean {
+
+    private reset() {
+        this.rendered = null;
+        this.previewPageStatus = "";
+        this.images = [];
+        this.imageError = "";
+        this.error = "";
+    }
+
+    private get TargetChanged(): boolean {
         let current = currentDiagram();
         if (!current) return false;
         let changed = (!this.rendered || !this.rendered.isEqual(current));
@@ -148,6 +93,15 @@ class Previewer extends vscode.Disposable {
         }
         return changed;
     }
+
+    private async update(processingTip: boolean) {
+        if (this.taskKilling) return;
+        await this.killTasks();
+        // console.log("updating...");
+        // do not await doUpdate, so that preview window could open before update task finish.
+        this.doUpdate(processingTip).catch(e => showMessagePanel(e));
+    }
+
     private async doUpdate(processingTip: boolean) {
         let diagram = currentDiagram();
         if (!diagram) {
@@ -206,12 +160,66 @@ class Previewer extends vscode.Disposable {
             }
         );
     }
+
+    private updateWebView(): string {
+        let env = {
+            localize: localize,
+            images: this.images.reduce((p, c) => {
+                if (c.startsWith('data:image/')) {
+                    return `${p}<img src="${c}">`
+                } else {
+                    return `${p}${c.replaceAll('<area ', '<area target="_blank"')}`
+                }
+            }, ""),
+            imageError: "",
+            error: "",
+            status: this.previewPageStatus,
+            // nonce: Math.random().toString(36).substr(2),
+            icon: "file:///" + path.join(extensionPath, "images", "icon.png"),
+            settings: JSON.stringify({
+                zoomUpperLimit: this.zoomUpperLimit,
+                showSpinner: this.status === previewStatus.processing,
+                showSnapIndicators: config.previewSnapIndicators,
+                swapMouseButtons: config.previewSwapMouseButtons,
+            }),
+        };
+        try {
+            switch (this.status) {
+                case previewStatus.default:
+                case previewStatus.error:
+                    env.imageError = this.imageError;
+                    env.error = this.error.replace(/\n/g, "<br />");
+                    this._uiPreview.show("preview.html", env);
+                    break;
+                case previewStatus.processing:
+                    env.error = "";
+                    env.images = ["svg", "png"].reduce((p, c) => {
+                        if (p) return p;
+                        let exported = calculateExportPath(this.rendered, c);
+                        exported = addFileIndex(exported, 0, this.rendered.pageCount);
+                        return fs.existsSync(exported) ? env.images = `<img src="${fileToBase64(exported)}">` : "";
+                    }, "");
+                    this._uiPreview.show("preview.html", env);
+                    break;
+                default:
+                    break;
+            }
+        } catch (error) {
+            return error
+        }
+    }
+
+    private setUIStatus(status: string) {
+        this.previewPageStatus = status;
+    }
+
     //display processing tip
-    processing() {
+    private processing() {
         this.status = previewStatus.processing;
         this.updateWebView();
     }
-    register() {
+
+    private register() {
         let disposable: vscode.Disposable;
 
         //register command
@@ -222,7 +230,7 @@ class Previewer extends vscode.Disposable {
                 let diagrams = diagramsOf(editor.document);
                 if (!diagrams.length) return;
 
-                //reset in case that starting commnad in none-diagram area, 
+                //reset in case that starting commnad in none-diagram area,
                 //or it may show last error image and may cause wrong "TargetChanged" result on cursor move.
                 this.reset();
                 this.TargetChanged;
@@ -251,7 +259,8 @@ class Previewer extends vscode.Disposable {
         this._uiPreview.addEventListener("open", () => this.startWatch());
         this._uiPreview.addEventListener("close", () => { this.stopWatch(); this.killTasks(); });
     }
-    startWatch() {
+
+    private startWatch() {
         let disposable: vscode.Disposable;
         let disposables: vscode.Disposable[] = [];
 
@@ -284,7 +293,8 @@ class Previewer extends vscode.Disposable {
 
         this.watchDisposables = disposables;
     }
-    stopWatch() {
+
+    private stopWatch() {
         for (let d of this.watchDisposables) {
             d.dispose();
         }

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -227,7 +227,7 @@ class Previewer extends vscode.Disposable {
             try {
                 var editor = vscode.window.activeTextEditor;
                 if (!editor) return;
-                let diagrams = diagramsOf(editor.document);
+                let diagrams = diagramsOf(editor.document, editor.viewColumn);
                 if (!diagrams.length) return;
 
                 //reset in case that starting commnad in none-diagram area,

--- a/src/providers/previewer.ts
+++ b/src/providers/previewer.ts
@@ -301,5 +301,12 @@ class Previewer extends vscode.Disposable {
         }
         this.watchDisposables = [];
     }
+
+    async showSource() {
+        if (!this.rendered) return;
+        const { document, start, viewColumn } = this.rendered;
+        const selection = new vscode.Range(start, start);
+        await vscode.window.showTextDocument(document, { selection, viewColumn });
+    }
 }
 export const previewer = new Previewer();


### PR DESCRIPTION
This PR adds a new command that allows users to quickly navigate from a preview window back to the source diagram file.

**Changes**
- New Command: Added `plantuml.showSource` command that opens the source file of the currently previewed diagram
- UI Integration: Added a navigation button in the preview panel's title bar that appears when viewing a preview
- Localization: Added translations for the new command across all supported languages
- Internal Improvements:
    - Store `viewColumn` information in `Diagram` class for proper editor positioning
    - Refactored preview update logic by splitting the `TargetChanged` function for better maintainability
    - Reorganized and made several internal functions private for cleaner encapsulation

**User Experience**
When previewing a PlantUML diagram, users can now click the "Show Diagram Source" button in the preview panel's title bar to immediately jump back to the source file in the editor, maintaining the same view column layout.