### PR TITLE
Add Preview Location Setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ Export Settings:
 
 Preview Settings:
 
-- `plantuml.previewAutoUpdate`: Dedecides if automatically update the preview window.
+- `plantuml.previewAutoUpdate`: Decides if automatically update the preview window.
+- `plantuml.previewLocationSide`: Decides if to show the preview window at the side of the editor.
 
 Other Settings:
 

--- a/package.json
+++ b/package.json
@@ -277,6 +277,12 @@
           "default": true,
           "description": "%plantuml.configuration.previewAutoUpdate%"
         },
+        "plantuml.previewLocationSide": {
+          "type": "boolean",
+          "scope": "application",
+          "default": true,
+          "description": "%plantuml.configuration.previewLocationSide%"
+        },
         "plantuml.previewSnapIndicators": {
           "type": "boolean",
           "scope": "application",

--- a/package.nls.da.json
+++ b/package.nls.da.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "Tæller antal eksporteringer når der eksporteres flere diagrammer.",
 	"plantuml.configuration.exportOutDir": "Eksporterede Workspace-diagrammer vil blive placeret i denne mappe (relativt til Workspace-mappe).",
 	"plantuml.configuration.previewAutoUpdate": "Auto-opdatér preview-vindue.",
+	"plantuml.configuration.previewLocationSide": "Afgør om preview-vinduet skal vises ved siden af editoren.",
 	"plantuml.configuration.previewSnapIndicators": "Vis snap-indikatorer i preview-vindue.",
 	"plantuml.configuration.server": "PlantUML-server til at generere UML-diagrammer på farten. You may use official server https://www.plantuml.com/plantuml if you feel OK to share data with it.",
 	"plantuml.configuration.urlFormat": "URL format. Lad være blankt for at vælge format hver gang der laves et URL.",

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "Anzahl von gleichzeitigen Exports bei mehreren Diagrammen.",
 	"plantuml.configuration.exportOutDir": "Exported workspace diagrams will be organized in this directory  (relative path to workspace folder).",
 	"plantuml.configuration.previewAutoUpdate": "Automatisch das Vorschaufenster aktualisieren.",
+	"plantuml.configuration.previewLocationSide": "Legt fest, ob das Vorschaufenster seitlich neben dem Editor angezeigt werden soll.",
 	"plantuml.configuration.previewSnapIndicators": "Decides if to display the snap indicators in the preview window.",
 	"plantuml.configuration.previewSwapMouseButtons": "Linke und rechte Maustaste für Zoom bzw. Verschieben des Bildinhaltes vertauschen.",
 	"plantuml.configuration.server": "Plantuml-Server zum Generieren von UML-Diagrammen on-the-fly. You may use official server https://www.plantuml.com/plantuml if you feel OK to share data with it.",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -16,6 +16,7 @@
   "plantuml.configuration.exportConcurrency": "Permite ajustar el nivel de concurrencia al exportar múltiples diagramas.",
   "plantuml.configuration.exportOutDir": "Los diagramas exportados del espacio de trabajo serán organizados en este directorio (con respecto al directorio del espacio de trabajo).",
   "plantuml.configuration.previewAutoUpdate": "Permite ajustar si la ventana de previsualización debería actualizarse automáticamente.",
+  "plantuml.configuration.previewLocationSide": "Permite ajustar si la ventana de previsualización debe mostrarse al lado del editor.",
   "plantuml.configuration.previewSnapIndicators": "Permite ajustar si el control para mantener el diagrama fijado a un borde (abajo/derecha/arriba/izquierda), también conocido como \"Snap\", debe mostrarse en la ventana de previsualización.",
   "plantuml.configuration.server": "Servidor de PlantUml para generar diagramas sobre la marcha. Puedes usar el servidor oficial en https://www.plantuml.com/plantuml si estás de acuerdo en compartir datos con este.",
   "plantuml.configuration.urlFormat": "Formato de URL. Dejar en blanco para elegir un formato cada vez que creas una URL.",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "Nombres de 'threads' à utiliser lors de l'exportation de plusieurs diagrammes en parallèle :",
 	"plantuml.configuration.exportOutDir": "Les diagrammes exportés de l'espace de travail seront à cette adresse (relatif au dossier de l'espace de travail).",
 	"plantuml.configuration.previewAutoUpdate": "Activation de l'aperçu automatique.",
+	"plantuml.configuration.previewLocationSide": "Détermine si la fenêtre d'aperçu doit s'afficher sur le côté de l'éditeur.",
 	"plantuml.configuration.previewSnapIndicators": "Activation des indicateurs de limites dans la fenêtre d'aperçu.",
 	"plantuml.configuration.server": "URL du serveur Plantuml lors de l'utilisation du moteur de rendu 'PlantUMLServer'. Vous pouvez utiliser le serveur officiel https://www.plantuml.com/plantuml si vous êtes prêt à partager des données (non confidentielles) avec lui.",
 	"plantuml.configuration.urlFormat": "Format d'exportation utilisé lors de la génération de l'URL. Laissez vide pour avoir le choix à chaque exportation.",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "複数のダイアグラムをエクスポートする際の並列実行数の設定します",
 	"plantuml.configuration.exportOutDir": "エクスポートされたワークスペースのダイアグラムは、このディレクトリに整理されます(ワークスペース内のディレクトリへの相対パス)。",
 	"plantuml.configuration.previewAutoUpdate": "プレビューウィンドウを自動的に更新するかを指定します",
+	"plantuml.configuration.previewLocationSide": "プレビューウィンドウをエディターの横に表示するかどうかを決定します。",
 	"plantuml.configuration.previewSnapIndicators": "プレビューウィンドウにスナップインジケーターを表示するかどうかを決定します。",
 	"plantuml.configuration.server": "その場でUMLダイアグラムを生成するPlantUMLサーバーを指定します。データを共有しても問題ないと思われる方は、公式サーバ https://www.plantuml.com/plantuml をご利用ください。",
 	"plantuml.configuration.urlFormat": "URL形式を指定。空白の場合はURLを生成するたびにフォーマットを選択します",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "Decides concurrency count when export multiple diagrams.",
 	"plantuml.configuration.exportOutDir": "Exported workspace diagrams will be organized in this directory (relative path to workspace folder).",
 	"plantuml.configuration.previewAutoUpdate": "Decides if automatically update the preview window.",
+	"plantuml.configuration.previewLocationSide": "Decides if to show the preview window at the side of the editor.",
 	"plantuml.configuration.previewSnapIndicators": "Decides if to display the snap indicators in the preview window.",
 	"plantuml.configuration.previewSwapMouseButtons": "Swaps left and right mouse buttons used for zooming or panning",
 	"plantuml.configuration.server": "Plantuml server to generate UML diagrams on-the-fly. You may use official server https://www.plantuml.com/plantuml if you feel OK to share data with it.",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "여러개의 다이어그램을 내보내기 할 때 동시작업개수를 지정합니다.",
 	"plantuml.configuration.exportOutDir": "내보낸 작업공간 다이어그램이 이 디렉터리에 보관됩니다.  (작업공간의 상대 폴더).",
 	"plantuml.configuration.previewAutoUpdate": "미리보기 화면을 자동으로 업데이트할지를 결정합니다.",
+	"plantuml.configuration.previewLocationSide": "미리보기 창을 편집기 옆에 표시할지를 결정합니다.",
 	"plantuml.configuration.previewSnapIndicators": "미리보기 화면에서 스냅 지시자를 표시할지를 결정합니다.",
 	"plantuml.configuration.server": "UML 다이어그램을 바로 생성할 수 있는 Plantuml 서버. 데이터가 공개되도 괜찮다면 https://www.plantuml.com/plantuml 공식서버를 사용할 수 있습니다.",
 	"plantuml.configuration.urlFormat": "URL 형식. URL을 만들 때마다 선택하려면 비워두십시오.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "Допустимое Количество потоков при экспорте более, чем 1 диаграммы.",
 	"plantuml.configuration.exportOutDir": "Экспортированные из рабочего пространства диаграммы будут находиться в этой папке (относительный путь от корневой папки рабочего пространства).",
 	"plantuml.configuration.previewAutoUpdate": "Указывает, обновлять, или не обновлять окно предпросмотра автоматически.",
+	"plantuml.configuration.previewLocationSide": "Определяет, показывать ли окно предпросмотра сбоку от редактора.",
 	"plantuml.configuration.previewSnapIndicators": "Указывает, отображать, или не отображать индикаторы закрепления в области предпросмотра.",
 	"plantuml.configuration.previewSwapMouseButtons": "Инвертирует функции ЛКМ и ПКМ в окне предпросмотра.",
 	"plantuml.configuration.server": "Сервер PlantUML для генерации диаграмм на лету. вы можете использовать официальный сервер https://www.plantuml.com/plantuml если считаете, что отправка на него ваших данных не нанесёт вам ущерб.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "决定导出多个图表时的并发数量。",
 	"plantuml.configuration.exportOutDir": "所有导出图片将被组织到此目录下（相对于工作区目录的路径）。",
 	"plantuml.configuration.previewAutoUpdate": "决定是否在内容变更和选定图表变更时自动刷新预览窗口",
+	"plantuml.configuration.previewLocationSide": "决定是否在编辑器侧边显示预览窗口。",
 	"plantuml.configuration.previewSnapIndicators": "决定是否在预览窗口中显示吸附提示。",
 	"plantuml.configuration.previewSwapMouseButtons": "在预览窗口中交换左右键功能(默认左键缩放，右键平移；启用后左键平移，右键绽放)",
 	"plantuml.configuration.server": "生成图表超链接使用的 Plantuml 服务器。您可以使用官方的 https://www.plantuml.com/plantuml 如果您可以接受向其发送数据。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -16,6 +16,7 @@
 	"plantuml.configuration.exportConcurrency": "決定匯出多個圖表的時候同時執行的數量。",
 	"plantuml.configuration.exportOutDir": "Exported workspace diagrams will be organized in this directory  (relative path to workspace folder).",
 	"plantuml.configuration.previewAutoUpdate": "決定是否要在内容變更的時候自動更新預覽的圖片",
+	"plantuml.configuration.previewLocationSide": "決定是否要在編輯器側邊顯示預覽視窗。",
 	"plantuml.configuration.previewSnapIndicators": "Decides if to display the snap indicators in the preview window.",
 	"plantuml.configuration.server": "產生圖表使用的 Plantuml 伺服器。You may use official server https://www.plantuml.com/plantuml if you feel OK to share data with it.",
 	"plantuml.configuration.urlFormat": "超鏈接檔案格式。 若留空，則在每次產生的時候選擇格式。",

--- a/src/plantuml/config.ts
+++ b/src/plantuml/config.ts
@@ -103,6 +103,10 @@ class Config extends ConfigReader {
         return this.read<boolean>('previewAutoUpdate');
     }
 
+    get previewLocationSide(): boolean {
+        return this.read<boolean>('previewLocationSide');
+    }
+
     get previewSnapIndicators(): boolean {
         return this.read<boolean>('previewSnapIndicators');
     }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -3,8 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { showMessagePanel } from '../plantuml/tools';
 import { UIEventMap, MessageEvent, UIListener, UIEvent } from './events';
-
-const DEFAULT_VIEWCOLUMN = vscode.ViewColumn.Two;
+import { config } from '../plantuml/config';
 
 export class UI extends vscode.Disposable {
     _panel: vscode.WebviewPanel;
@@ -47,7 +46,7 @@ export class UI extends vscode.Disposable {
         } else {
             let file = args[0] as string;
             let env = args[1];
-            viewColumn = args[2] || (this._panel ? this._panel.viewColumn : DEFAULT_VIEWCOLUMN);
+            viewColumn = args[2] || (this._panel ? this._panel.viewColumn : this.defaultViewColumn);
             this.createIfNoPanel(viewColumn);
             this.update(file, env);
         }
@@ -76,7 +75,7 @@ export class UI extends vscode.Disposable {
         this._panel = vscode.window.createWebviewPanel(
             this._viewType,
             this._title,
-            viewColumn ? viewColumn : DEFAULT_VIEWCOLUMN,
+            viewColumn ?? this.defaultViewColumn,
             <vscode.WebviewOptions>{
                 enableScripts: true,
                 enableCommandUris: false,
@@ -90,6 +89,10 @@ export class UI extends vscode.Disposable {
             this.dispose();
             this._panel = undefined;
         }, this, this._disposables);
+    }
+
+    private get defaultViewColumn(): vscode.ViewColumn {
+        return config.previewLocationSide ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active;
     }
 
     private addMessageListener() {


### PR DESCRIPTION
This PR introduces a new setting to control where the PlantUML preview window opens in VS Code.

**Changes**
- New Setting: `plantuml.previewLocationSide` (default: `true`)
  - When `true`: Opens preview in a new editor column beside the current one (`ViewColumn.Beside`)
  - When `false`: Opens preview in the active column (`ViewColumn.Active`)
- Implementation:
  - Added configuration property to `config.ts`
  - Modified `ui.ts` to use the setting value instead of hardcoded `ViewColumn.Two`
  - Replaced `DEFAULT_VIEWCOLUMN` constant with dynamic `defaultViewColumn` getter
- Documentation: Updated `README.md` and all localization files with the new setting description

**Benefits**
Gives users control over preview behavior, accommodating different workflow preferences without changing the default experience for existing users.