### PR TITLE
Remove Panel Reveal Logic

### DIFF
--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -51,8 +51,6 @@ export class UI extends vscode.Disposable {
             this.createIfNoPanel(viewColumn);
             this.update(file, env);
         }
-        if (!this._panel.visible || viewColumn !== this._panel.viewColumn)
-            this._panel.reveal(viewColumn ? viewColumn : this._panel.viewColumn);
     }
     close() {
         this.dispose();


### PR DESCRIPTION
This PR removes the automatic panel reveal behavior when updating the PlantUML preview panel.

**Changes**
- Removed the logic that automatically revealed/focused the preview panel when it was updated or when the view column changed
- This prevents the preview panel from stealing focus from the editor when the user is actively working

**Why**
The automatic reveal behavior was disruptive to the user experience, as it would unexpectedly shift focus away from the editor whenever the preview updated. This change allows the preview to update in the background without interrupting the user's workflow - especially for users who have the preview open in the active column instead of the beside column.

Closes #582
Closes #217